### PR TITLE
sync verbosity #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# build artifacts
 /target
+
+# profiling artifacts
 perf.data
+
+# coverage artifacts
 *.profraw
+.coverage/

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -150,7 +150,10 @@ impl<'a> Cli<'a> {
 
     pub fn run(&self) -> Result<()> {
         match self.args.subcommand() {
-            ("completions", Some(sub_matches)) => self.print_completions(sub_matches),
+            ("completions", Some(sub_matches)) => {
+                self.print_completions(sub_matches);
+                Ok(())
+            }
             (subcommand, Some(sub_matches)) => {
                 let args = CliArgs::from(sub_matches);
                 let exec = CmdExec::init(subcommand, &args)?;
@@ -160,7 +163,7 @@ impl<'a> Cli<'a> {
         }
     }
 
-    fn print_completions(&self, sub_matches: &clap::ArgMatches) -> Result<()> {
+    fn print_completions(&self, sub_matches: &clap::ArgMatches) {
         let shell = clap::Shell::from_str(sub_matches.value_of("shell").unwrap()).unwrap();
         let mut app = Cli::build_cli(self.defaults);
         let _stdout = stdout();
@@ -168,7 +171,7 @@ impl<'a> Cli<'a> {
         let mut writer = _stdout.lock();
         #[cfg(test)]
         let mut writer = std::io::sink();
-        Ok(app.gen_completions_to(crate_name!(), shell, &mut writer))
+        app.gen_completions_to(crate_name!(), shell, &mut writer);
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,17 +3,17 @@ use std::io;
 
 #[derive(Debug)]
 pub enum Error {
-    SyncError(io::Error),
-    UserDirectories(String),
-    ImplementationNotFound(String),
+    AttributeTypeMismatch(String),
     CliError(String),
+    DirectoryReadError(io::Error),
     DocumentNotFound(String),
     DocumentParseError(io::Error),
-    MetadataRetrieval(String),
-    MetadataNotFound(String),
     DuplicateAttribute(String),
-    AttributeTypeMismatch(String),
-    DirectoryReadError(io::Error),
+    ImplementationNotFound(String),
+    MetadataNotFound(String),
+    MetadataRetrieval(String),
+    SyncError(io::Error),
+    UserDirectories(String),
 }
 
 impl From<io::Error> for Error {

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -e
+
+_usage() {
+    cat <<EOF
+usage:
+    ./test.sh [lint|cover|bench|all]
+EOF
+}
+
+_test() {
+    cargo test
+}
+
+_lint() {
+    cargo clippy -- -D warnings
+    cargo fmt -- --check
+}
+
+_coverage() {
+    cargo="cargo +nightly"
+    output=".coverage"
+
+    export RUSTFLAGS="-Zinstrument-coverage"
+
+    ${cargo} clean
+    ${cargo} test --lib 
+    rustup run nightly grcov . --binary-path target/debug/ \
+                               --source-dir . \
+                               --branch \
+                               --ignore-not-existing \
+                               --ignore "/*" \
+                               --excl-line 'panic!' \
+                               --output-type "html" \
+                               --output-path "${output}"
+    echo "Opening report in browser"
+    ${BROWSER:-firefox} "${output}/src/index.html"
+}
+
+_bench() {
+    cargo build --release
+    hyperfine 'target/release/rfz index'
+}
+
+cmd="$1"
+case "${cmd}" in
+    "")
+        _test;;
+    lint)
+        _lint;;
+    cover)
+        _coverage;;
+    bench)
+        _bench;;
+    all)
+        _test
+        _lint
+        _bench
+        _coverage
+        ;;
+    *)
+        _usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
resolves #3

- re-order error variants
- add 'completions' sub-command
- fix linting errors
- ignore coverage artifacts
- add test wrapper script
- add verbosity flag
